### PR TITLE
some progress towards something

### DIFF
--- a/Modules/Prelims/uniproof.v
+++ b/Modules/Prelims/uniproof.v
@@ -191,16 +191,54 @@ Section LiftEpi.
            iscontr (Σ c : C, Σ
 *)  
 
-
-   ∃! y : C, ∃ a : A, (p a = b × f a = y).
-
-  Lemma comp_f_epi_hprop : Π b : pr1 B, iscontr (image (fun (x:hfiber p b) => f (pr1 x))).
+(*
+  Lemma comp_f_epi_hprop : Π b : pr1 B, ∃! y : pr1 C, ∃ a : pr1 A, (p a = b × f a = y).
   Proof.
-    intro b.
+        intro b.
     unfold image.
     unfold hfiber. cbn.
 
     
+    apply (squash_to_prop (surjectivep b)).
+    { apply isapropiscontr. }
+    intro H.
+    apply iscontraprop1.
+    - apply invproofirrelevance.
+      intros c c'.
+      apply subtypeEquality.
+      + intro. apply isapropishinh.
+      + destruct c as [c cp].
+        destruct c' as [c' cp']. 
+        cbn.
+        
+    
+    
+    
+
+(*
+    Search (  isaprop ?X → ?X →  iscontr ?X).
+*)
+    
+(* inspiré de     isapropimeqclass *)
+    Print hsubtypes.    
+    intros x1 x2.
+    apply (@hinhuniv2 _ _ (hProppair _ (pr2 C (x1) ( x2)))).
+    simpl;
+    intros y1 y2; simpl.
+    unfold hfiber in y1,y2.
+    destruct y1 as [ [z1 h1] h1' ].
+    destruct y2 as [ [z2 h2] h2' ].
+    rewrite <- h1' ,<-h2'.
+    apply comp_f_epi;simpl.
+    rewrite h1,h2.
+    apply idpath.
+    
+    apply prtoimage. apply H.
+*)
+
+  Lemma comp_f_epi_hprop : Π b : pr1 B, iscontr (image (fun (x:hfiber p b) => f (pr1 x))).
+  Proof.
+    intro b.
     apply (squash_to_prop (surjectivep b)).
     { apply isapropiscontr. }
     intro H.
@@ -232,12 +270,39 @@ Section LiftEpi.
     apply (pr1 (pr1 (comp_f_epi_hprop b))).
   Defined.
   
-  
   Lemma lift_epi_ax : Π x,  lift_epi (p x) = f x.
   Proof.
     intro x.
     apply pathsinv0.
+    apply path_to_ctr.
+    apply (squash_to_prop (surjectivep (p x))). 
+    { apply isapropishinh. }
+    intro r. apply hinhpr.
+    exists r.
+    apply comp_f_epi.
+    apply (pr2 r).
+  Defined.
+
+  Lemma lift_epi_unique : Π (g : SET⟦B, C⟧) (H : Π a : pr1 A, g (p a) = f a)
+                            (b : pr1 B), g b = lift_epi b.
+  Proof.
+    intros g H b.
+    apply path_to_ctr.
+    apply (squash_to_prop (surjectivep b)). 
+    { apply isapropishinh. }
+    intros [a Ha].
+    apply hinhpr.
+    mkpair.
+    - exists a. apply Ha.
+    - simpl.
+      rewrite <- H.
+      rewrite Ha.
+      apply idpath.
+Defined.
+
     
+  
+  
  
 
   Definition lift_epi : SET ⟦B, C⟧.

--- a/Modules/Prelims/uniproof.v
+++ b/Modules/Prelims/uniproof.v
@@ -181,12 +181,34 @@ Section LiftEpi.
 
 
 
-  Hypothesis (comp_f_epi: Π x y,  p x =  p y -> f x = f y).
+  Hypothesis (comp_f_epi: Π x y, p x =  p y -> f x = f y).
+  Hypothesis (surjectivep : issurjective p).
 
   (* Reformulation of the previous hypothesis *)
-  Lemma comp_f_epi_hprop : Π b : pr1 B, isaprop (image (fun (x:hfiber ( p) b) => f (pr1 x))).
+
+(*
+  Lemma comp_f_epi_hprop : Π b : pr1 B, 
+           iscontr (Σ c : C, Σ
+*)  
+
+
+   ∃! y : C, ∃ a : A, (p a = b × f a = y).
+
+  Lemma comp_f_epi_hprop : Π b : pr1 B, iscontr (image (fun (x:hfiber p b) => f (pr1 x))).
   Proof.
     intro b.
+    unfold image.
+    unfold hfiber. cbn.
+
+    
+    apply (squash_to_prop (surjectivep b)).
+    { apply isapropiscontr. }
+    intro H.
+    apply iscontraprop1.
+(*
+    Search (  isaprop ?X → ?X →  iscontr ?X).
+*)
+    
 (* inspiré de     isapropimeqclass *)
     apply isapropsubtype.
     intros x1 x2.
@@ -200,27 +222,53 @@ Section LiftEpi.
     apply comp_f_epi;simpl.
     rewrite h1,h2.
     apply idpath.
-  Qed.
+    
+    apply prtoimage. apply H.
+  Defined.
 
-  Hypothesis (surjectivep : issurjective p).
+  Definition lift_epi : SET ⟦B, C⟧.
+  Proof.
+    intro b.
+    apply (pr1 (pr1 (comp_f_epi_hprop b))).
+  Defined.
+  
+  
+  Lemma lift_epi_ax : Π x,  lift_epi (p x) = f x.
+  Proof.
+    intro x.
+    apply pathsinv0.
+    
+ 
 
   Definition lift_epi : SET ⟦B, C⟧.
     (* inspiré de setquotuniv *)
     intros b.
-    assert (c:(hProppair _  (comp_f_epi_hprop b))).
+    apply f.
+    
+    
+    transparent assert (c:(hProppair _  (comp_f_epi_hprop b))).
     {
-    generalize (surjectivep b).
-    apply hinhuniv.
-    apply prtoimage.
+(*    generalize (surjectivep b). *)
+      use (hinhuniv _ (surjectivep b )); cbn.
+      apply prtoimage.
     }
     exact (pr1 c).
   Defined.
-
+  
+  Search ( ∥ _ ∥ ).
+  
   Lemma lift_epi_ax : Π x,  lift_epi (p x) = f x.
   Proof.
     intro x.
     cbn.
-    unfold lift_epi.
+    unfold lift_epi.  cbn. 
+    apply (squash_to_prop (surjectivep (p x))).
+    {  apply setproperty. }
+    
+    squash_to_prop
+    
+    apply idpath.
+    Search hinhuniv.
     unfold hinhuniv; cbn.
     
     match goal with |- pr1 ?x = _ => set (z:=x) end.


### PR DESCRIPTION
Given 
```
A ----------> C
|         f
| p
v
B
```
such that p and f are compatible in some sense, 
construct a map `lift_epi f : B -> C` 
- such that the triangle commutes and
- this map is the only one that makes the triangle commute
.