### PR TITLE
Epi only initial

### DIFF
--- a/Modules/Prelims/lib.v
+++ b/Modules/Prelims/lib.v
@@ -37,6 +37,20 @@ Proof.
   reflexivity.
 Qed.
 
+Lemma preserves_to_HSET_isEpi (ax_choice : AxiomOfChoice.AxiomOfChoice_surj)
+      (B := hset_category)  {C : category}
+      (G : functor B C)
+      { a b : B}
+      (f : (B ⟦ a, b⟧)%Cat)
+  : isEpi f
+    -> isEpi (#G f)%Cat.
+Proof.
+  intros epif.
+  apply isSplitEpi_isEpi; [ apply homset_property|].
+  apply preserves_isSplitEpi.
+  apply SplitEpis_HSET; [|apply epif].
+  apply ax_choice.
+Qed.
 (*
 Lemma isEpi_pre_whisker (B C :precategory)(D : category)
       (G H : functor C D) (K : functor B C) (f : nat_trans G H)
@@ -123,6 +137,8 @@ Qed.
 *)
 
 
+(* inutile, c'est juste la composition de deux morphismes *)
+(*
 Lemma isEpi_horcomp_pw (B : precategory)(C D : category)
       (G H : functor B C) (G' H' : functor C D)
       (f : nat_trans G H) (f':nat_trans G' H')
@@ -153,6 +169,7 @@ Proof.
   apply SplitEpis_HSET; [|apply epig].
   apply choice.
 Qed.
+*)
 (*
 Lemma isEpi_horcomp (B : precategory)(C D : category)
       (G H : functor B C) (G' H' : functor C D)

--- a/Modules/Prelims/quotientmonad.v
+++ b/Modules/Prelims/quotientmonad.v
@@ -67,10 +67,13 @@ Proof.
   apply isEpi_pr_quot_functor.
 Qed.
 
+
 (* Lemma isEpi_projR_projR_pw x : isEpi (C:=functor_category _ _) (projR ∙∙ projR x). *)
 Lemma isEpi_projR_projR_pw x : isEpi  ((projR ∙∙ projR) x).
 Proof.
-  apply isEpi_horcomp_pw_HSET; apply choice || apply isEpi_projR_pw. 
+  apply isEpi_comp.
+  - apply isEpi_projR_pw.
+  - apply preserves_to_HSET_isEpi; apply choice || apply isEpi_projR_pw. 
 Qed.
 
 
@@ -198,7 +201,11 @@ Qed.
 
 Lemma isEpi_projR_projR_projR_pw c : isEpi ((projR ∙∙ (projR ∙∙ projR)) c).
 Proof.
-  apply isEpi_horcomp_pw_HSET; [apply choice | apply isEpi_projR_projR_pw| apply isEpi_projR_pw].
+  apply isEpi_comp.
+  - apply isEpi_projR_pw.
+  - apply preserves_to_HSET_isEpi.
+    + apply choice.
+    + apply isEpi_projR_projR_pw. 
 Defined.
 
 Lemma R'_Monad_law_μ : ∏ c : SET,

--- a/Modules/Prelims/quotientrep.v
+++ b/Modules/Prelims/quotientrep.v
@@ -214,13 +214,14 @@ Proof.
                   ((h ∙∙ projR) X)
          ).
   {
-    apply isEpi_horcomp_pw_HSET.
-    - exact choice.
-    - apply isEpi_projR_pw.
+    apply isEpi_comp.
     - intro Y.
       apply Pushouts_pw_epi.
       * apply PushoutsHSET_from_Colims.
       * apply isEpih.
+    - apply preserves_to_HSET_isEpi.
+      + exact choice.
+      + apply isEpi_projR_pw.
   }
   apply epi.
   etrans; [ apply τ'_law_eq1 |].

--- a/Modules/Prelims/uniproofalt.v
+++ b/Modules/Prelims/uniproofalt.v
@@ -436,9 +436,9 @@ Qed.
 Definition isEpi_FR' : UU 
   := isEpi (C:=functor_precategory HSET HSET has_homsets_HSET)
                              (pr1 (F R'_monad)).
-Definition isEpi_FR  : UU 
-  := isEpi (C:=functor_precategory HSET HSET has_homsets_HSET)
-                             (pr1 (F (pr1 R))).
+(* Definition isEpi_FR  : UU  *)
+(*   := isEpi (C:=functor_precategory HSET HSET has_homsets_HSET) *)
+(*                              (pr1 (F (pr1 R))). *)
 
 Definition EpiArity (c : arity SET) :=
   ∏ M N (f:category_Monad _⟦M,N⟧),
@@ -474,7 +474,9 @@ Conditions that we require to prove that [hab] is epimorphic :
 either [a] is an epi arity and [F R'] is an epi, either [b] is an epi-arity
 and [F R] is an epi
 *)
-Definition cond_isEpi_hab := (isEpi_FR' × EpiArity a) ⨿ (isEpi_FR × EpiArity b).
+Definition cond_isEpi_hab :=
+  (isEpi_FR' × EpiArity a) ⨿
+                           (isEpi (C := [_, _]) (pr1 (F (pr1 R))) × EpiArity b).
 
 
 Context (cond_hab : cond_isEpi_hab).
@@ -673,8 +675,8 @@ Definition build_module (R : Rep_a) (cond_R :   cond_isEpi_hab R)
     )
       := (_ ,, build_module_law R cond_R S m).
   
-
-Theorem push_initiality (R : Rep_a) (epi_F : isEpi_FR R) (epib : EpiArity b) :
+Theorem push_initiality (R : Rep_a) (epi_F : isEpi (C := [_, _]) (pr1 (F (pr1 R))))
+        (epib : EpiArity b) :
     isInitial _ R -> Initial Rep_b.
 Proof.
   intro iniR.

--- a/Modules/Prelims/uniproofalt.v
+++ b/Modules/Prelims/uniproofalt.v
@@ -379,6 +379,27 @@ Proof.
     apply (F R'_monad).
 Defined.
 
+(**
+By naturality of F,
+
+<<<<
+
+       hab
+   a_R --> b_R'
+    |     ^
+    |    /
+F_R |   / b_π
+    |  /
+    V /
+    b_R 
+
+>>>>
+where π := projR
+
+ *)
+(* Lemma hab_alt : hab =  *)
+(*    ( pb_LModule_Mor projR_monad (F R'_monad) ;; # a projR_monad)%mor *)
+
 (** This is the compatibility relation that is needed to construct
 R'_rep_τ : b R -> R
 *)
@@ -411,10 +432,39 @@ Qed.
 Definition isEpi_FR' : UU 
   := isEpi (C:=functor_precategory HSET HSET has_homsets_HSET)
                              (pr1 (F R'_monad)).
+
+Definition EpiArity (c : arity SET) :=
+  ∏ M N (f:category_Monad _⟦M,N⟧),
+     isEpi (C := functor_category _ _) (pr1 f) -> isEpi (C:= functor_category _ _)
+                                                       (pr1 (#c f)%ar).
+
+(** For the explicit subsitution arity example *)
+Example EpiArityThetaTheta (choice : AxiomOfChoice.AxiomOfChoice_surj)
+        {M N} (f:category_Monad SET ⟦M,N⟧) :
+     isEpi (C := functor_category _ _) (pr1 f) -> isEpi (C:= functor_category _ _)
+                                                       (horcomp (pr1 f )(pr1 f )).
+Proof.
+  intro hepi.
+  apply is_nat_trans_epi_from_pointwise_epis.
+  assert (hf : ∏ x, isEpi (pr1 f x)).
+  {
+    apply Pushouts_pw_epi.
+    - apply PushoutsHSET_from_Colims.
+    - exact hepi.
+  }
+  intro x.
+  apply isEpi_comp.
+  - apply hf.
+  - apply preserves_to_HSET_isEpi.
+    + apply choice.
+    + apply hf.
+Qed.
+   
+
+
 (* a preserve les epis *)
 Definition a_preserves_epi : UU 
-  := ∏ M N (f:category_Monad _⟦M,N⟧),
-     isEpi (C := functor_category _ _) (pr1 f) -> isEpi (C:= functor_category _ _) (pr1 (#a f)%ar).
+  := EpiArity a.
 
 Context (Fepi:isEpi_FR') (aepi:a_preserves_epi).
 

--- a/Modules/Prelims/uniproofalt.v
+++ b/Modules/Prelims/uniproofalt.v
@@ -432,13 +432,6 @@ Proof.
 Qed.
 
 
-(* F preserve the epis *)
-Definition isEpi_FR' : UU 
-  := isEpi (C:=functor_precategory HSET HSET has_homsets_HSET)
-                             (pr1 (F R'_monad)).
-(* Definition isEpi_FR  : UU  *)
-(*   := isEpi (C:=functor_precategory HSET HSET has_homsets_HSET) *)
-(*                              (pr1 (F (pr1 R))). *)
 
 Definition EpiArity (c : arity SET) :=
   ∏ M N (f:category_Monad _⟦M,N⟧),
@@ -475,7 +468,7 @@ either [a] is an epi arity and [F R'] is an epi, either [b] is an epi-arity
 and [F R] is an epi
 *)
 Definition cond_isEpi_hab :=
-  (isEpi_FR' × EpiArity a) ⨿
+  (isEpi (C := [_, _]) (pr1 (F R'_monad)) × EpiArity a) ⨿
                            (isEpi (C := [_, _]) (pr1 (F (pr1 R))) × EpiArity b).
 
 
@@ -698,7 +691,9 @@ Qed.
 (* TODO : remplacer Fepi par isEpi F (comme dans le papier) et déduire la version pointwise *)
 Context (aepi : EpiArity a).
 
-Lemma helper (Fepi : forall R, isEpi_FR' R)  (R : Rep_a)
+Let R'_monad R  := R'_monad ax_choice (congr_equivc R) (compat_μ_projR R).
+
+Lemma helper (Fepi : forall R, isEpi (C := [_, _]) (pr1 (F (R'_monad R))))  (R : Rep_a)
       (cond_F := inl (dirprodpair (Fepi R) aepi ) : cond_isEpi_hab R)
   (S : rep_ar SET b)
   : ∏ (u' : Rep_b ⟦ R'_rep R cond_F, S ⟧) x,
@@ -724,7 +719,7 @@ Proof.
 Qed.
 
 
-Definition is_right_adjoint_functor_of_reps (Fepi : forall R, isEpi_FR' R) : 
+Definition is_right_adjoint_functor_of_reps (Fepi : forall R, isEpi (C := [_, _]) (pr1 (F (R'_monad R))) ) : 
                                               is_right_adjoint FF.
 Proof.
   set (cond_F := fun R => inl ((Fepi R),, aepi) : cond_isEpi_hab R).


### PR DESCRIPTION
le théorème alternatif s'appelle [push_initiality].
on suppose que l'arité cible préserve les épis et que F_R est un épi où R est la rep initiale de a. On en déduit la représentabilité de l'arité b